### PR TITLE
Fix bug in gradle setting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,6 @@ repositories {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:+'
+    compile 'com.android.support:support-v4:25+'
     compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
When there are multiple project dependencies with different gradle
settings, lack of an accurate version number for android.support lib
will cause error below:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-getui:processReleaseResources'.
> com.android.ide.common.process.ProcessException: Failed to execute
aapt
```