### PR TITLE
rename GtSdkRN.podspec to RCTGetuiModule.podspec

### DIFF
--- a/RCTGetuiModule.podspec
+++ b/RCTGetuiModule.podspec
@@ -3,7 +3,7 @@ pjson = JSON.parse(File.read('package.json'))
 
 Pod::Spec.new do |s|
 
-  s.name            = "GtSdkRN"
+  s.name            = "RCTGetuiModule"
   s.version         = pjson["version"]
   s.homepage        = "https://github.com/GetuiLaboratory/react-native-getui"
   s.summary         = pjson["description"]


### PR DESCRIPTION
By renaming the podspec file, we avoid manual editing of
header file search path. This way, 'pod install' is all one
needs to do to integrate for ios.